### PR TITLE
change `b"Males`" to `"Males"`

### DIFF
--- a/labs/ex02/template/helpers.py
+++ b/labs/ex02/template/helpers.py
@@ -12,7 +12,7 @@ def load_data(sub_sample=True, add_outlier=False):
     weight = data[:, 1]
     gender = np.genfromtxt(
         path_dataset, delimiter=",", skip_header=1, usecols=[0],
-        converters={0: lambda x: 0 if b"Male" in x else 1})
+        converters={0: lambda x: 0 if "Male" in x else 1})
     # Convert to metric system
     height *= 0.025
     weight *= 0.454


### PR DESCRIPTION
There is a typo in one of the helper files. Removing the `b` fixes it.