### PR TITLE
Change pip command to use %pip in notebook

### DIFF
--- a/labs/mini-project/llm_getting_started_notebook/demo.ipynb
+++ b/labs/mini-project/llm_getting_started_notebook/demo.ipynb
@@ -75,7 +75,7 @@
     }
    ],
    "source": [
-    "!pip install -q datasets==4.0.0 tokenizers tiktoken matplotlib tqdm huggingface_hub==1.7.1 fsspec==2023.10.0"
+    "%pip install -q datasets==4.0.0 tokenizers tiktoken matplotlib tqdm huggingface_hub==1.7.1 fsspec==2023.10.0"
    ]
   },
   {


### PR DESCRIPTION
Using ! fails in EPFL gnoto. Easy fix is to change ! with %.